### PR TITLE
repo name fixed from gitlab to github

### DIFF
--- a/methods.go
+++ b/methods.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
-	"gitlab.com/thejini3/blog-to-pdf/sitemap"
+	"github.com/thejini3/blog-to-pdf/sitemap"
 	"strconv"
 )
 

--- a/readme.md
+++ b/readme.md
@@ -2,8 +2,8 @@
 
 ```
 brew cask install wkhtmltopdf
-go get gitlab.com/thejini3/blog-to-pdf
-cd $GOPATH/src/gitlab.com/thejini3/blog-to-pdf
+go get github.com/thejini3/blog-to-pdf
+cd $GOPATH/src/github.com/thejini3/blog-to-pdf
 go install
 ```
 


### PR DESCRIPTION
There are some mistakes of repo name, 

> "gitlab.com/thejini3/blog-to-pdf/sitemap"

 it should be 

> "github.com/thejini3/blog-to-pdf/sitemap"

Due to this, go get was failing.

Also there are similar mistakes in the README.md file. Fixed it.